### PR TITLE
Fix non-strict syntax by removing global return

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,8 +14,10 @@ var stream
 if(process.stdin.isTTY) {
   if(process.argv[2])
     stream = fs.createReadStream(process.argv[2])
-  else
-    return usage()
+  else {
+    usage()
+    process.exit(0)
+  }
 }
 else
   stream = process.stdin


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683